### PR TITLE
Fix search results fetch all

### DIFF
--- a/src/config-schema.json
+++ b/src/config-schema.json
@@ -179,6 +179,11 @@
                   "type": "boolean",
                   "default": false
                 },
+                "enableSingleLayerMode" : {
+                  "description": "If there is only one layer with search, enable single panel mode of Search Results.",
+                  "type": "boolean",
+                  "default": true
+                },
                 "highlightFillColor": {
                     "description": "The fill color of highlighted footprints/bounding boxes on the map. Any valid CSS color defintion is supported.",
                     "type": "string",

--- a/src/main.js
+++ b/src/main.js
@@ -215,6 +215,7 @@ window.Application = Marionette.Application.extend({
       rightPanelOpen: false,
       leftPanelTabIndex: 0,
       rightPanelTabIndex: 0,
+      enableSingleLayerMode: true,
       downloadFormats: [],
       downloadProjections: [],
       uploadEnabled: true,
@@ -416,7 +417,7 @@ window.Application = Marionette.Application.extend({
       termsAndConditionsUrl = termsAndConditionsUrl[settings.language];
     }
 
-    if (searchCollection.length === 1) {
+    if (searchCollection.length === 1 && settings.enableSingleLayerMode) {
       // single layer view
       layout.showChildView('rightPanel', new SidePanelView({
         position: 'right',

--- a/src/mundi_single.html
+++ b/src/mundi_single.html
@@ -264,7 +264,7 @@
                 "searchLimit": 300,
                 "loadMore": 300,
                 "switchMultiPolygonCoordinates": true,
-                "searchEnabled": false,
+                "searchEnabled": true,
                 "parameters": [
                     {
                       "title": "Online Status",

--- a/src/views/combined/CombinedResultView.js
+++ b/src/views/combined/CombinedResultView.js
@@ -121,8 +121,6 @@ const CombinedResultView = Marionette.LayoutView.extend({
   },
 
   downloadListItemRemoved() {
-    const view = this.getRegion('results').currentView;
-    view.referenceCollection.set(this.singleModel.get('downloadSelection'));
     this.updateViews();
   },
 

--- a/src/views/combined/CombinedResultView.js
+++ b/src/views/combined/CombinedResultView.js
@@ -162,7 +162,8 @@ const CombinedResultView = Marionette.LayoutView.extend({
     const height = elem.clientHeight;
     let sizeAccum = 0;
     const view = this.getRegion('results').currentView;
-    view.setSlice(sizeAccum - scrollTop, height);
+    if (typeof view !== 'undefined')
+    this.setSlice(sizeAccum - scrollTop, height, view);
     sizeAccum += view.$el.outerHeight(true);
     elem.scrollTop = scrollTop;
   },

--- a/src/views/combined/CombinedResultView.js
+++ b/src/views/combined/CombinedResultView.js
@@ -45,6 +45,7 @@ const CombinedResultView = Marionette.LayoutView.extend({
   className: 'search-result-view',
 
   events: {
+    'change input[data-layer]': 'onLayerSelectionChange',
     'click .deselect-all': 'onDeselectAllClicked',
     'click .start-download': 'onStartDownloadClicked',
     'click .download-as-metalink': 'onDownloadAsMetalinkClicked',
@@ -122,7 +123,7 @@ const CombinedResultView = Marionette.LayoutView.extend({
   downloadListItemRemoved() {
     const view = this.getRegion('results').currentView;
     view.referenceCollection.set(this.singleModel.get('downloadSelection'));
-    this.onSearchListRender();
+    this.updateViews();
   },
 
   renderResultContent() {
@@ -160,11 +161,10 @@ const CombinedResultView = Marionette.LayoutView.extend({
     const elem = this.$('.result-contents')[0];
     const scrollTop = elem.scrollTop;
     const height = elem.clientHeight;
-    let sizeAccum = 0;
     const view = this.getRegion('results').currentView;
-    if (typeof view !== 'undefined')
-    this.setSlice(sizeAccum - scrollTop, height, view);
-    sizeAccum += view.$el.outerHeight(true);
+    if (typeof view !== 'undefined' && typeof view.referenceCollection !== 'undefined') {
+      this.setSlice(-scrollTop, height, view);
+    }
     elem.scrollTop = scrollTop;
   },
 
@@ -205,7 +205,7 @@ const CombinedResultView = Marionette.LayoutView.extend({
   },
 
   setSlice(offset, sliceHeight, view) {
-    const size = this.calculateSize();
+    const size = this.calculateSize(view);
     const headerHeight = 0;
     const itemHeight = 153;
     const numItems = view.referenceCollection.length;
@@ -238,6 +238,16 @@ const CombinedResultView = Marionette.LayoutView.extend({
     const footerHeight = 0;
     return this.calculateItemsSize(view.referenceCollection.length)
       + headerHeight + footerHeight;
+  },
+
+  onLayerSelectionChange(event) {
+    if (event) {
+      const $changed = $(event.target);
+      this.singleModel.set('automaticSearch', $changed.is(':checked'));
+      this.saveScrollPosition();
+      this.render();
+    }
+    this.onSearchModelsChange();
   },
 
   onTermsAndAndConditionsChange(childView, status) {

--- a/src/views/combined/DownloadListView.hbs
+++ b/src/views/combined/DownloadListView.hbs
@@ -1,7 +1,9 @@
 <ul class="search-result-list list-unstyled list-inline">
   <div class="panel-result-list">
     <div class="panel-body">
+      <div class="spacer spacer-top"/>
       <ul class="selection-items list-unstyled list-inline result-list"></ul>
+      <div class="spacer spacer-bottom"/>
     </div>
   </div>
 </ul>

--- a/src/views/combined/DownloadListView.js
+++ b/src/views/combined/DownloadListView.js
@@ -28,7 +28,6 @@ const DownloadListView = Marionette.CompositeView.extend({
     this.fallbackThumbnailUrl = options.fallbackThumbnailUrl;
     this.searchModel = options.searchModel;
     this.referenceCollection = options.referenceCollection;
-    // this.listenTo(this.model, 'change', this.render, this);
     this.listenTo(this.searchModel.get('downloadSelection'), 'update', this.onDownloadListItemRemoved);
   },
 

--- a/src/views/combined/DownloadListView.js
+++ b/src/views/combined/DownloadListView.js
@@ -27,6 +27,7 @@ const DownloadListView = Marionette.CompositeView.extend({
     this.highlightModel = options.highlightModel;
     this.fallbackThumbnailUrl = options.fallbackThumbnailUrl;
     this.searchModel = options.searchModel;
+    this.referenceCollection = options.referenceCollection;
     this.listenTo(this.model, 'change', this.render, this);
     this.listenTo(this.searchModel.get('downloadSelection'), 'update', this.onDownloadListItemRemoved);
   },

--- a/src/views/combined/DownloadListView.js
+++ b/src/views/combined/DownloadListView.js
@@ -1,7 +1,7 @@
+import Backbone from 'backbone';
 import Marionette from 'backbone.marionette';
 
 import SelectionListItemView from 'eoxc/src/download/views/SelectionListItemView';
-
 import template from './DownloadListView.hbs';
 
 const DownloadListView = Marionette.CompositeView.extend({
@@ -17,10 +17,23 @@ const DownloadListView = Marionette.CompositeView.extend({
     });
   },
 
+  constructor(options) {
+    Marionette.CompositeView.prototype.constructor.call(this, Object.assign({}, options, {
+      collection: new Backbone.Collection(),
+    }));
+  },
+
   initialize(options) {
     this.highlightModel = options.highlightModel;
     this.fallbackThumbnailUrl = options.fallbackThumbnailUrl;
-    this.collection = options.collection;
+    this.searchModel = options.searchModel;
+    this.listenTo(this.model, 'change', this.render, this);
+    this.listenTo(this.searchModel.get('downloadSelection'), 'update', this.onDownloadListItemRemoved);
+  },
+
+  onDownloadListItemRemoved() {
+    // passing event up to parent
+    this.triggerMethod('downloadlist:itemRemoved');
   },
 });
 

--- a/src/views/combined/DownloadListView.js
+++ b/src/views/combined/DownloadListView.js
@@ -28,8 +28,12 @@ const DownloadListView = Marionette.CompositeView.extend({
     this.fallbackThumbnailUrl = options.fallbackThumbnailUrl;
     this.searchModel = options.searchModel;
     this.referenceCollection = options.referenceCollection;
-    this.listenTo(this.model, 'change', this.render, this);
+    // this.listenTo(this.model, 'change', this.render, this);
     this.listenTo(this.searchModel.get('downloadSelection'), 'update', this.onDownloadListItemRemoved);
+  },
+
+  onRender() {
+    this.triggerMethod('list:render');
   },
 
   onDownloadListItemRemoved() {

--- a/src/views/combined/SearchResultListView.hbs
+++ b/src/views/combined/SearchResultListView.hbs
@@ -2,7 +2,7 @@
   <div class="panel-result-list">
     <div class="panel-body">
         <div class="spacer spacer-top"/>
-          <ul class="result-list list-inline list-unstyled"></ul>
+        <ul class="result-list list-inline list-unstyled"></ul>
         <div class="spacer spacer-bottom"/>
     </div>
   </div>

--- a/src/views/combined/SearchResultListView.js
+++ b/src/views/combined/SearchResultListView.js
@@ -71,41 +71,6 @@ const SearchResultListView = Marionette.CompositeView.extend({
     this.highlightModel.unHighlight(childView.model.attributes);
   },
 
-  setSlice(offset, sliceHeight) {
-    const size = this.calculateSize();
-    const headerHeight = 0;
-    const itemHeight = 153;
-    const numItems = this.referenceCollection.length;
-    let first = 0;
-    let last = 0;
-    if (offset + size < 0 // this view is completely above the current window
-        || offset > sliceHeight) { // this view is completely below the current window
-      first = last = numItems;
-    } else {
-      const firstOffset = offset + headerHeight;
-      if (firstOffset < -itemHeight) {
-        const firstRow = Math.floor(Math.abs(firstOffset) / itemHeight);
-        first = firstRow * 3;
-      }
-      const lastRow = Math.ceil(Math.abs(-firstOffset + sliceHeight) / itemHeight);
-      last = lastRow * 3;
-    }
-    this.collection.set(this.referenceCollection.slice(first, last));
-    this.$('.spacer-top').css('height', Math.ceil(first / 3) * itemHeight);
-    this.$('.spacer-bottom').css('height', Math.ceil((numItems - last) / 3) * itemHeight);
-  },
-
-  calculateItemsSize(numItems) {
-    const itemHeight = 153;
-    return Math.ceil(numItems / 3) * itemHeight;
-  },
-
-  calculateSize() {
-    const headerHeight = 0;
-    const footerHeight = 0;
-    return this.calculateItemsSize(this.referenceCollection.length)
-      + headerHeight + footerHeight;
-  },
 });
 
 export default SearchResultListView;

--- a/src/views/combined/SearchResultListView.js
+++ b/src/views/combined/SearchResultListView.js
@@ -46,7 +46,6 @@ const SearchResultListView = Marionette.CompositeView.extend({
     this.highlightModel = options.highlightModel;
     this.fallbackThumbnailUrl = options.fallbackThumbnailUrl;
     this.referenceCollection = options.referenceCollection;
-    this.listenTo(this.model, 'change', this.render, this);
   },
 
   onRender() {

--- a/src/views/combined/SearchResultListView.js
+++ b/src/views/combined/SearchResultListView.js
@@ -28,10 +28,6 @@ const SearchResultListView = Marionette.CompositeView.extend({
     });
   },
 
-  events: {
-    render: 'onRender',
-  },
-
   childEvents: {
     'item:clicked': 'onItemClicked',
     'item:info': 'onItemInfo',


### PR DESCRIPTION
- single layer mode - replicated search results behavior, where only thumbnails of items currently visible in search results list are fetched, to basket too - this saves a lot of bandwidth when selected (n) is clicked
- both panels now share a remembered scroll
- single layer mode can now be disabled - config: enableSingleLayerMode:false (default true)